### PR TITLE
[worker] Sneakers::Worker#run: add configurable retries for calling S…

### DIFF
--- a/lib/sneakers/configuration.rb
+++ b/lib/sneakers/configuration.rb
@@ -50,6 +50,7 @@ module Sneakers
 
       :consume_from_sharded_pseudoqueue => false,
       :queue_subscribe_exclusive => false,
+      :queue_subscribe_attempts => 10,
     }.freeze
 
 


### PR DESCRIPTION
…neakers::Queue#subscribe

What:

This allows configuring an upper limit on the number of attempts to
retry running the `Sneakers::Queue#subscribe` method.

Why:

For exclusively consuming from a sharded rabbitmq_sharding pseudoqueue,
retries are normal and expected when encountering a Bunny::Exception,
due to racing consumers being assigned to the same underlying queue, and
then having to retry in order for the server broker to assign a
different queue.

---

JIRA: QI-508

---

Test run output showing all tests passing:

```
 normful-sneakers-fork » docker build -t normful-sneakers-fork_sneakers:latest . && docker run --rm normful-sneakers-fork_sneakers:latest
Sending build context to Docker daemon  2.134MB
Step 1/7 : FROM ruby:2.3-alpine
 ---> b1ef280f0eba
Step 2/7 : RUN apk add --no-cache git
 ---> Using cache
 ---> a778f4d3f643
Step 3/7 : RUN apk --update add --virtual build_deps build-base ruby-dev libc-dev linux-headers openssl-dev
 ---> Using cache
 ---> cd01c4a25e55
Step 4/7 : ADD . /sneakers
 ---> 39ba339312a3
Step 5/7 : WORKDIR /sneakers
 ---> Running in c7dab0a2109a
Removing intermediate container c7dab0a2109a
 ---> 58a8a7c2c01b
Step 6/7 : RUN bundle --jobs=4 --retry=3
 ---> Running in 2f8bc98e0e4c
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Fetching rake 12.3.2
Installing rake 12.3.2
Fetching abstract_type 0.0.7
Fetching concurrent-ruby 1.1.4
Fetching minitest 5.11.3
Installing abstract_type 0.0.7
Fetching thread_safe 0.3.6
Installing minitest 5.11.3
Fetching ice_nine 0.11.2
Installing concurrent-ruby 1.1.4
Installing thread_safe 0.3.6
Installing ice_nine 0.11.2
Fetching public_suffix 3.0.3
Fetching amq-protocol 2.3.0
Installing amq-protocol 2.3.0
Fetching arrayfields 4.9.2
Installing public_suffix 3.0.3
Fetching ast 2.4.0
Installing arrayfields 4.9.2
Using bundler 1.17.2
Fetching parallel 1.13.0
Fetching chronic 0.10.2
Installing ast 2.4.0
Installing parallel 1.13.0
Fetching hirb 0.7.3
Installing chronic 0.10.2
Fetching json_pure 2.1.0
Installing hirb 0.7.3
Fetching fattr 2.4.0
Installing json_pure 2.1.0
Installing fattr 2.4.0
Fetching map 6.6.0
Fetching unf_ext 0.0.7.5
Installing map 6.6.0
Fetching mime-types-data 3.2018.0812
Fetching netrc 0.11.0
Installing unf_ext 0.0.7.5 with native extensions
Installing netrc 0.11.0
Installing mime-types-data 3.2018.0812
Fetching sexp_processor 4.11.0
Installing sexp_processor 4.11.0
Fetching code_metrics 0.1.3
Fetching coderay 1.1.2
Installing code_metrics 0.1.3
Fetching equalizer 0.0.11
Installing coderay 1.1.2
Installing equalizer 0.0.11
Fetching diff-lcs 1.2.5
Fetching docile 1.3.1
Installing docile 1.3.1
Installing diff-lcs 1.2.5
Fetching erubis 2.7.0
Fetching multipart-post 2.0.0
Installing multipart-post 2.0.0
Fetching ffi 1.10.0
Installing erubis 2.7.0
Fetching path_expander 1.0.3
Installing ffi 1.10.0 with native extensions
Installing path_expander 1.0.3
Fetching formatador 0.2.5
Installing formatador 0.2.5
Fetching rb-fsevent 0.10.3
Installing rb-fsevent 0.10.3
Fetching ruby_dep 1.5.0
Installing ruby_dep 1.5.0
Fetching lumberjack 1.0.13
Installing lumberjack 1.0.13
Fetching nenv 0.3.0
Installing nenv 0.3.0
Fetching shellany 0.0.1
Installing shellany 0.0.1
Fetching method_source 0.9.2
Installing method_source 0.9.2
Fetching thor 0.20.3
Installing thor 0.20.3
Fetching guard-compat 1.2.1
Installing guard-compat 1.2.1
Fetching hashie 3.6.0
Installing hashie 3.6.0
Fetching json 2.1.0
Installing json 2.1.0 with native extensions
Fetching metric_fu-Saikuro 1.1.3
Installing metric_fu-Saikuro 1.1.3
Fetching multi_json 1.13.1
Installing multi_json 1.13.1
Fetching require_all 2.0.0
Installing require_all 2.0.0
Fetching ruby-progressbar 1.10.0
Installing ruby-progressbar 1.10.0
Fetching redcard 1.1.0
Installing redcard 1.1.0
Fetching rainbow 2.2.2
Installing rainbow 2.2.2 with native extensions
Fetching procto 0.0.3
Installing procto 0.0.3
Fetching redis 4.1.0
Installing redis 4.1.0
Fetching rr 1.2.1
Installing rr 1.2.1
Fetching ruby-prof 0.17.0
Installing ruby-prof 0.17.0 with native extensions
Fetching sigdump 0.2.4
Installing sigdump 0.2.4
Fetching simplecov-html 0.10.2
Installing simplecov-html 0.10.2
Fetching simplecov-rcov-text 0.0.3
Installing simplecov-rcov-text 0.0.3
Fetching tzinfo 1.2.5
Fetching memoizable 0.4.2
Installing tzinfo 1.2.5
Installing memoizable 0.4.2
Fetching i18n 1.5.3
Fetching bunny 2.9.2
Installing i18n 1.5.3
Fetching addressable 2.6.0
Fetching cane 2.6.2
Installing bunny 2.9.2
Installing cane 2.6.2
Fetching parser 2.2.0.4
Installing addressable 2.6.0
Fetching main 6.2.2
Fetching mime-types 3.2.2
Installing parser 2.2.0.4
Installing mime-types 3.2.2
Installing main 6.2.2
Fetching ruby_parser 3.12.0
Fetching code_analyzer 0.4.8
Installing code_analyzer 0.4.8
Fetching faraday 0.13.1
Installing faraday 0.13.1
Fetching notiffany 0.1.1
Fetching pry 0.12.2
Installing ruby_parser 3.12.0
Installing notiffany 0.1.1
Fetching guard-minitest 2.4.6
Installing pry 0.12.2
Installing guard-minitest 2.4.6
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching rb-inotify 0.10.0
Fetching serverengine 2.0.7
Fetching adamantium 0.2.0
Installing rb-inotify 0.10.0
Fetching simplecov 0.16.1
Installing adamantium 0.2.0
Installing serverengine 2.0.7
Installing simplecov 0.16.1
Fetching activesupport 5.2.2
Fetching launchy 2.4.3
Fetching faraday_middleware 0.12.2
Installing launchy 2.4.3
Installing faraday_middleware 0.12.2
Fetching flay 2.12.0
Fetching flog 4.6.2
Installing activesupport 5.2.2
Installing flay 2.12.0
Installing flog 4.6.2
Fetching roodi 3.3.1
Fetching domain_name 0.5.20180417
Installing roodi 3.3.1
Installing domain_name 0.5.20180417
Fetching listen 3.1.5
Installing listen 3.1.5
Fetching concord 0.1.5
Using sneakers 2.7.0 from source at `.`
Fetching rabbitmq_http_api_client 1.11.0
Installing concord 0.1.5
Fetching http-cookie 1.0.3
Installing rabbitmq_http_api_client 1.11.0
Fetching guard 2.15.0
Fetching unparser 0.2.2
Installing http-cookie 1.0.3
Installing unparser 0.2.2
Fetching rails_best_practices 1.19.4
Installing guard 2.15.0
Installing rails_best_practices 1.19.4
Fetching rest-client 2.0.2
Fetching reek 2.2.1
Installing rest-client 2.0.2
Installing reek 2.2.1
Fetching churn 0.0.35
Installing churn 0.0.35
Fetching metric_fu 4.12.0
Installing metric_fu 4.12.0
Bundle complete! 13 Gemfile dependencies, 93 gems now installed.
Bundled gems are installed into `/usr/local/bundle`
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0

Post-install message from rails_best_practices:
********************************************************************************

  rails_best_practices is a code metric tool to check the quality of rails codes.

  I highly recommend you browse the Rails Best Practices website first.

      http://rails-bestpractices.com

  Enjoy!

      Richard Huang (flyerhzm@gmail.com)

********************************************************************************
Removing intermediate container 2f8bc98e0e4c
 ---> 8c2c64d654f6
Step 7/7 : CMD rake test
 ---> Running in 920d187e6f8d
Removing intermediate container 920d187e6f8d
 ---> 909dc2a41dcb
Successfully built 909dc2a41dcb
Successfully tagged normful-sneakers-fork_sneakers:latest
REDIS is at localhost
Run options: --seed 52572

\# Running:

...................................................SS........................................................................

Finished in 1.600392s, 78.1059 runs/s, 79.9804 assertions/s.

125 runs, 128 assertions, 0 failures, 0 errors, 2 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for RSpec to /sneakers/coverage. 565 / 611 LOC (92.47%) covered.
```